### PR TITLE
Simplify GCP deployment Dockerfile

### DIFF
--- a/gcp-migration/Dockerfile.bestpractice
+++ b/gcp-migration/Dockerfile.bestpractice
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.3
+FROM --platform=$BUILDPLATFORM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+ENV PYTHONPATH=/app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src/
+
+ENV CODE_ASSISTANT_PORT=8080
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+CMD ["python3", "src/mcp_server_standalone.py"]
+

--- a/gcp-migration/README.md
+++ b/gcp-migration/README.md
@@ -148,7 +148,7 @@ MCP serveren er nu klar til integration med Trae IDE:
 ### 4. Deployment Commands for Fuld RAG:
 ```bash
 # Build og deploy fuld RAG version
-docker buildx build --platform linux/amd64 -f Dockerfile.phase2 \
+docker buildx build --platform linux/amd64 -f Dockerfile.bestpractice \
   -t gcr.io/code-assistant-rag/code-assistant-rag:v3-full . --push
 
 # Update Cloud Run service med mere resources
@@ -183,7 +183,7 @@ git clone <repository-url>
 cd gcp-migration
 
 # Build og kør MCP server lokalt
-docker build -f Dockerfile.direct -t code-assistant-rag:mcp .
+docker build -f Dockerfile.bestpractice -t code-assistant-rag:mcp .
 docker run -p 8080:8080 code-assistant-rag:mcp
 
 # Test lokalt
@@ -208,10 +208,7 @@ python3 src/mcp_server_standalone.py
 ```
 gcp-migration/
 ├── README.md                      # Denne fil (opdateret)
-├── Dockerfile.direct              # MCP Server (DEPLOYED ✅)
-├── Dockerfile.phase2              # Fuld RAG implementation
-├── Dockerfile.simple              # Simpel version med Ollama
-├── Dockerfile.minimal             # Minimal version
+├── Dockerfile.bestpractice        # Unified production Dockerfile
 ├── requirements.txt               # Python dependencies
 ├── src/
 │   ├── mcp_server_standalone.py   # MCP Server (LIVE ✅)


### PR DESCRIPTION
## Summary
- add `Dockerfile.bestpractice` with a simple production setup
- update README to reference the new Dockerfile

## Testing
- `python3 -m py_compile gcp-migration/src/mcp_server_standalone.py`
- `python3 -m py_compile gcp-migration/src/rag_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68404ee54bbc832aa3ecc94507e862a5